### PR TITLE
:bug: Coffee Smoke > Fix Chrome smoothstep crash

### DIFF
--- a/coffee-smoke/src/script.js
+++ b/coffee-smoke/src/script.js
@@ -2,7 +2,7 @@ import GUI from 'lil-gui'
 import * as THREE from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
-import { MeshBasicNodeMaterial, mix, mul, positionLocal, smoothstep, texture, timerGlobal, tslFn, uv, vec2, vec3, vec4 } from 'three/examples/jsm/nodes/Nodes.js'
+import { MeshBasicNodeMaterial, mix, mul, positionLocal, smoothstep, texture, timerGlobal, oneMinus, tslFn, uv, vec2, vec3, vec4 } from 'three/examples/jsm/nodes/Nodes.js'
 import WebGPURenderer from 'three/examples/jsm/renderers/webgpu/WebGPURenderer.js'
 
 /**
@@ -71,9 +71,9 @@ smokeMaterial.colorNode = tslFn(() =>
     const alpha = mul(
         texture(noiseTexture, alphaNoiseUv).r.smoothstep(0.4, 1),
         smoothstep(0, 0.1, uv().x),
-        smoothstep(1, 0.9, uv().x),
+        smoothstep(0, 0.1, oneMinus(uv().x)),
         smoothstep(0, 0.1, uv().y),
-        smoothstep(1, 0.9, uv().y)
+        smoothstep(0, 0.1, oneMinus(uv().y))
     )
     const finalColor = mix(vec3(0.6, 0.3, 0.2), vec3(1, 1, 1), alpha.pow(3))
 


### PR DESCRIPTION
Hi 👋 

Currently, running the `coffee-smoke` example on Chrome makes the WGSL program crash with this error:

![image](https://github.com/user-attachments/assets/305e447a-9856-40b2-8b06-daf2465982dd)

MrDoob already fixed the issue in the main Three repo : https://github.com/mrdoob/three.js/pull/29265

The fix is not perfect as the initial values make an artifact appears on the first frame (probably linked to time usage). The artifact is not present in the more recent versions of Three.js with the same code: https://threejs.org/examples/?q=smoke#webgpu_tsl_coffee_smoke (not sure if you want to upgrade three version or not)

![image](https://github.com/user-attachments/assets/b9969456-ff2e-48b1-b741-837f23f29157)

I saw other examples such as `vfx-1` or `vfx-tornado` that might need a similar fix like this one.

**Keep up the good work, Three.js Journey is awesome 🎉**  